### PR TITLE
feat: Add chart of accounts for Switzerland

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/ch_240812 Schulkontenrahmen VEB - DE.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/ch_240812 Schulkontenrahmen VEB - DE.json
@@ -1,0 +1,532 @@
+{
+	"country_code": "ch",
+	"name": "240812 Schulkontenrahmen VEB - DE",    
+    "tree": {
+        "Aktiven": {
+            "account_number": "1",
+            "is_group": 1,
+            "root_type": "Asset",
+            "Umlaufvermögen": {
+                "account_number": "10",
+                "is_group": 1,
+                "Flüssige Mittel": {
+                    "account_number": "100",
+                    "is_group": 1,
+                    "Kasse": {
+                        "account_number": "1000",
+                        "account_type": "Cash"
+                    },
+                    "Bankguthaben": {
+                        "account_number": "1020",
+                        "account_type": "Bank"
+                    }
+                },
+                "Kurzfristig gehaltene Aktiven mit Börsenkurs": {
+                    "account_number": "106",
+                    "is_group": 1,
+                    "Wertschriften": {
+                        "account_number": "1060"
+                    },
+                    "Wertberichtigungen Wertschriften": {
+                        "account_number": "1069"
+                    }
+                },
+                "Forderungen aus Lieferungen und Leistungen": {
+                    "account_number": "110",
+                    "is_group": 1,
+                    "Forderungen aus Lieferungen und Leistungen (Debitoren)": {
+                        "account_number": "1100"
+                    },
+                    "Delkredere": {
+                        "account_number": "1109"
+                    }
+                },
+                "Übrige kurzfristige Forderungen": {
+                    "account_number": "114",
+                    "is_group": 1,
+                    "Vorschüsse und Darlehen": {
+                        "account_number": "1140"
+                    },
+                    "Wertberichtigungen Vorschüsse und Darlehen": {
+                        "account_number": "1149"
+                    },
+                    "Vorsteuer MWST Material, Waren, Dienstleistungen, Energie": {
+                        "account_number": "1170"
+                    },
+                    "Vorsteuer MWST Investitionen, übriger Betriebsaufwand": {
+                        "account_number": "1171"
+                    },
+                    "Verrechnungssteuer": {
+                        "account_number": "1176"
+                    },
+                    "Forderungen gegenüber Sozialversicherungen und Vorsorgeeinrichtungen": {
+                        "account_number": "1180"
+                    },
+                    "Quellensteuer": {
+                        "account_number": "1189"
+                    },
+                    "Sonstige kurzfristige Forderungen": {
+                        "account_number": "1190"
+                    },
+                    "Wertberichtigungen sonstige kurzfristige Forderungen": {
+                        "account_number": "1199"
+                    }
+                },
+                "Vorräte und nicht fakturierte Dienstleistungen": {
+                    "account_number": "120",
+                    "is_group": 1,
+                    "Handelswaren": {
+                        "account_number": "1200"
+                    },
+                    "Rohstoffe": {
+                        "account_number": "1210"
+                    },
+                    "Werkstoffe": {
+                        "account_number": "1220"
+                    },
+                    "Hilfs- und Verbrauchsmaterial": {
+                        "account_number": "1230"
+                    },
+                    "Handelswaren in Konsignation": {
+                        "account_number": "1250"
+                    },
+                    "Fertige Erzeugnisse": {
+                        "account_number": "1260"
+                    },
+                    "Unfertige Erzeugnisse": {
+                        "account_number": "1270"
+                    },
+                    "Nicht fakturierte Dienstleistungen": {
+                        "account_number": "1280"
+                    }
+                },
+                "Aktive Rechnungsabgrenzungen": {
+                    "account_number": "130",
+                    "is_group": 1,
+                    "Bezahlter Aufwand des Folgejahres": {
+                        "account_number": "1300"
+                    },
+                    "Noch nicht erhaltener Ertrag": {
+                        "account_number": "1301"
+                    }
+                }
+            },
+            "Anlagevermögen": {
+                "account_number": "14",
+                "is_group": 1,
+                "Finanzanlagen": {
+                    "account_number": "140",
+                    "is_group": 1,
+                    "Wertschriften": {
+                        "account_number": "1400"
+                    },
+                    "Wertberichtigungen Wertschriften": {
+                        "account_number": "1409"
+                    },
+                    "Darlehen": {
+                        "account_number": "1440"
+                    },
+                    "Hypotheken": {
+                        "account_number": "1441"
+                    },
+                    "Wertberichtigungen langfristige Forderungen": {
+                        "account_number": "1449"
+                    }
+                },
+                "Beteiligungen": {
+                    "account_number": "148",
+                    "is_group": 1,
+                    "Beteiligungen": {
+                        "account_number": "1480"
+                    },
+                    "Wertberichtigungen Beteiligungen": {
+                        "account_number": "1489"
+                    }
+                },
+                "Mobile Sachanlagen": {
+                    "account_number": "150",
+                    "is_group": 1,
+                    "Maschinen und Apparate": {
+                        "account_number": "1500"
+                    },
+                    "Wertberichtigungen Maschinen und Apparate": {
+                        "account_number": "1509"
+                    },
+                    "Mobiliar und Einrichtungen": {
+                        "account_number": "1510"
+                    },
+                    "Wertberichtigungen Mobiliar und Einrichtungen": {
+                        "account_number": "1519"
+                    },
+                    "Büromaschinen, Informatik, Kommunikationstechnologie": {
+                        "account_number": "1520"
+                    },
+                    "Wertberichtigungen Büromaschinen, Informatik, Kommunikationstechnologie": {
+                        "account_number": "1529"
+                    },
+                    "Fahrzeuge": {
+                        "account_number": "1530"
+                    },
+                    "Wertberichtigungen Fahrzeuge": {
+                        "account_number": "1539"
+                    },
+                    "Werkzeuge und Geräte": {
+                        "account_number": "1540"
+                    },
+                    "Wertberichtigungen Werkzeuge und Geräte": {
+                        "account_number": "1549"
+                    }
+                },
+                "Immobile Sachanlagen": {
+                    "account_number": "160",
+                    "is_group": 1,
+                    "Geschäftsliegenschaften": {
+                        "account_number": "1600"
+                    },
+                    "Wertberichtigungen Geschäftsliegenschaften": {
+                        "account_number": "1609"
+                    }
+                },
+                "Immaterielle Werte": {
+                    "account_number": "170",
+                    "is_group": 1,
+                    "Patente, Know-how, Lizenzen, Rechte, Entwicklungen": {
+                        "account_number": "1700"
+                    },
+                    "Wertberichtigungen Patente, Know-how, Lizenzen, Rechte, Entwicklungen": {
+                        "account_number": "1709"
+                    },
+                    "Goodwill": {
+                        "account_number": "1770"
+                    },
+                    "Wertberichtigungen Goodwill": {
+                        "account_number": "1779"
+                    }
+                },
+                "Nicht einbezahltes Grund-, Gesellschafter- oder Stiftungskapital": {
+                    "account_number": "180",
+                    "is_group": 1,
+                    "Nicht einbezahltes Aktien-, Stamm-, Anteilschein- oder Stiftungskapital": {
+                        "account_number": "1850"
+                    }
+                }
+            }
+        },
+        "Passiven": {
+        "account_number": "2",
+        "is_group": 1,
+        "root_type": "Liability",
+            "Kurzfristiges Fremdkapital": {
+                "account_number": "20",
+                "is_group": 1,
+                "Verbindlichkeiten aus Lieferungen und Leistungen": {
+                    "account_number": "200",
+                    "is_group": 1,
+                    "Verbindlichkeiten aus Lieferungen und Leistungen (Kreditoren)": {
+                        "account_number": "2000"
+                    },
+                    "Erhaltene Anzahlungen": {
+                        "account_number": "2030"
+                    }
+                },
+                "Kurzfristige verzinsliche Verbindlichkeiten": {
+                    "account_number": "210",
+                    "is_group": 1,
+                    "Bankverbindlichkeiten": {
+                        "account_number": "2100"
+                    },
+                    "Verbindlichkeiten aus Finanzierungsleasing": {
+                        "account_number": "2120"
+                    },
+                    "Übrige verzinsliche Verbindlichkeiten": {
+                        "account_number": "2140"
+                    }
+                },
+                "Übrige kurzfristige Verbindlichkeiten": {
+                    "account_number": "220",
+                    "is_group": 1,
+                    "Geschuldete MWST (Umsatzsteuer)": {
+                        "account_number": "2200"
+                    },
+                    "Abrechnungskonto MWST": {
+                        "account_number": "2201"
+                    },
+                    "Verrechnungssteuer": {
+                        "account_number": "2206"
+                    },
+                    "Direkte Steuern": {
+                        "account_number": "2208"
+                    },
+                    "Sonstige kurzfristige Verbindlichkeiten": {
+                        "account_number": "2210"
+                    },
+                    "Beschlossene Ausschüttungen": {
+                        "account_number": "2261"
+                    },
+                    "Sozialversicherungen und Vorsorgeeinrichtungen": {
+                        "account_number": "2270"
+                    },
+                    "Quellensteuer": {
+                        "account_number": "2279"
+                    }
+                },
+                "Passive Rechnungsabgrenzungen und kurzfristige Rückstellungen": {
+                    "account_number": "230",
+                    "is_group": 1,
+                    "Noch nicht bezahlter Aufwand": {
+                        "account_number": "2300"
+                    },
+                    "Erhaltener Ertrag des Folgejahres": {
+                        "account_number": "2301"
+                    },
+                    "Kurzfristige Rückstellungen": {
+                        "account_number": "2330"
+                    }
+                }
+            },
+            "Langfristiges Fremdkapital": {
+                "account_number": "24",
+                "is_group": 1,
+                "Langfristige verzinsliche Verbindlichkeiten": {
+                    "account_number": "240",
+                    "is_group": 1,
+                    "Bankverbindlichkeiten": {
+                        "account_number": "2400"
+                    },
+                    "Verbindlichkeiten aus Finanzierungsleasing": {
+                        "account_number": "2420"
+                    },
+                    "Obligationenanleihen": {
+                        "account_number": "2430"
+                    },
+                    "Darlehen": {
+                        "account_number": "2450"
+                    },
+                    "Hypotheken": {
+                        "account_number": "2451"
+                    }
+                },
+                "Übrige langfristige Verbindlichkeiten": {
+                    "account_number": "250",
+                    "is_group": 1,
+                    "Übrige langfristige Verbindlichkeiten (unverzinslich)": {
+                        "account_number": "2500"
+                    }
+                },
+                "Rückstellungen sowie vom Gesetz vorgesehene ähnliche Positionen": {
+                    "account_number": "260",
+                    "is_group": 1,
+                    "Rückstellungen": {
+                        "account_number": "2600"
+                    }
+                }
+            },
+            "Eigenkapital (juristische Personen)": {
+                "account_number": "28",
+                "is_group": 1,
+                "Grund-, Gesellschafter- oder Stiftungskapital": {
+                    "account_number": "280",
+                    "is_group": 1,
+                    "Aktien-, Stamm-, Anteilschein- oder Stiftungskapital": {
+                        "account_number": "2800"
+                    }
+                },
+                "Reserven und Jahresgewinn oder Jahresverlust": {
+                    "account_number": "290",
+                    "is_group": 1,
+                    "Gesetzliche Kapitalreserve": {
+                        "account_number": "2900"
+                    },
+                    "Reserve für eigene Kapitalanteile": {
+                        "account_number": "2930"
+                    },
+                    "Aufwertungsreserve": {
+                        "account_number": "2940"
+                    },
+                    "Gesetzliche Gewinnreserve": {
+                        "account_number": "2950"
+                    },
+                    "Freiwillige Gewinnreserven": {
+                        "account_number": "2960"
+                    },
+                    "Gewinnvortrag oder Verlustvortrag": {
+                        "account_number": "2970"
+                    },
+                    "Jahresgewinn oder Jahresverlust": {
+                        "account_number": "2979"
+                    },
+                    "Eigene Aktien, Stammanteile oder Anteilscheine (Minusposten)": {
+                        "account_number": "2980"
+                    }
+                }
+            }
+        },
+        "Betrieblicher Ertrag aus Lieferungen und Leistungen": {
+            "account_number": "3",
+            "is_group": 1,
+            "root_type": "Income",
+            "Produktionserlöse": {
+                "account_number": "3000"
+            },
+            "Handelserlöse": {
+                "account_number": "3200"
+            },
+            "Dienstleistungserlöse": {
+                "account_number": "3400"
+            },
+            "Übrige Erlöse aus Lieferungen und Leistungen": {
+                "account_number": "3600"
+            },
+            "Eigenleistungen": {
+                "account_number": "3700"
+            },
+            "Eigenverbrauch": {
+                "account_number": "3710"
+            },
+            "Erlösminderungen": {
+                "account_number": "3800"
+            },
+            "Verluste Forderungen (Debitoren), Veränderung Delkredere": {
+                "account_number": "3805"
+            },
+            "Bestandesänderungen unfertige Erzeugnisse": {
+                "account_number": "3900"
+            },
+            "Bestandesänderungen fertige Erzeugnisse": {
+                "account_number": "3901"
+            },
+            "Bestandesänderungen nicht fakturierte Dienstleistungen": {
+                "account_number": "3940"
+            }
+        },
+        "Aufwand für Material, Handelswaren, Dienstleistungen und Energie": {
+            "account_number": "4",
+            "is_group": 1,
+            "root_type": "Expense",
+            "Materialaufwand Produktion": {
+                "account_number": "4000"
+            },
+            "Handelswarenaufwand": {
+                "account_number": "4200"
+            },
+            "Aufwand für bezogene Dienstleistungen": {
+                "account_number": "4400"
+            },
+            "Energieaufwand zur Leistungserstellung": {
+                "account_number": "4500"
+            },
+            "Aufwandminderungen": {
+                "account_number": "4900"
+            }
+        },
+        "Personalaufwand": {
+            "account_number": "5",
+            "is_group": 1,
+            "root_type": "Expense",
+            "Lohnaufwand": {
+                "account_number": "5000"
+            },
+            "Sozialversicherungsaufwand": {
+                "account_number": "5700"
+            },
+            "Übriger Personalaufwand": {
+                "account_number": "5800"
+            },
+            "Leistungen Dritter": {
+                "account_number": "5900"
+            }
+        },
+        "Übriger betrieblicher Aufwand, Abschreibungen und Wertberichtigungen sowie Finanzergebnis": {
+            "account_number": "6",
+            "is_group": 1,
+            "root_type": "Expense",
+            "Raumaufwand": {
+                "account_number": "6000"
+            },
+            "Unterhalt, Reparaturen, Ersatz mobile Sachanlagen": {
+                "account_number": "6100"
+            },
+            "Leasingaufwand mobile Sachanlagen": {
+                "account_number": "6105"
+            },
+            "Fahrzeug- und Transportaufwand": {
+                "account_number": "6200"
+            },
+            "Fahrzeugleasing und -mieten": {
+                "account_number": "6260"
+            },
+            "Sachversicherungen, Abgaben, Gebühren, Bewilligungen": {
+                "account_number": "6300"
+            },
+            "Energie- und Entsorgungsaufwand": {
+                "account_number": "6400"
+            },
+            "Verwaltungsaufwand": {
+                "account_number": "6500"
+            },
+            "Informatikaufwand inkl. Leasing": {
+                "account_number": "6570"
+            },
+            "Werbeaufwand": {
+                "account_number": "6600"
+            },
+            "Sonstiger betrieblicher Aufwand": {
+                "account_number": "6700"
+            },
+            "Abschreibungen und Wertberichtigungen auf Positionen des Anlagevermögens": {
+                "account_number": "6800"
+            },
+            "Finanzaufwand": {
+                "account_number": "6900"
+            },
+            "Finanzertrag": {
+                "account_number": "6950"
+            }
+        },
+        "Betrieblicher Nebenerfolg": {
+            "account_number": "7",
+            "is_group": 1,
+            "root_type": "Income",
+            "Ertrag Nebenbetrieb": {
+                "account_number": "7000"
+            },
+            "Aufwand Nebenbetrieb": {
+                "account_number": "7010"
+            },
+            "Ertrag betriebliche Liegenschaft": {
+                "account_number": "7500"
+            },
+            "Aufwand betriebliche Liegenschaft": {
+                "account_number": "7510"
+            }
+        },
+        "Betriebsfremder, ausserordentlicher, einmaliger oder periodenfremder Aufwand und Ertrag": {
+            "account_number": "8",
+            "is_group": 1,
+            "root_type": "Expense",
+            "Betriebsfremder Aufwand": {
+                "account_number": "8000"
+            },
+            "Betriebsfremder Ertrag": {
+                "account_number": "8100"
+            },
+            "Ausserordentlicher, einmaliger oder periodenfremder Aufwand": {
+                "account_number": "8500"
+            },
+            "Ausserordentlicher, einmaliger oder periodenfremder Ertrag": {
+                "account_number": "8510"
+            },
+            "Direkte Steuern": {
+                "account_number": "8900"
+            }
+        },
+        "Abschluss": {
+            "account_number": "9",
+            "is_group": 1,
+            "root_type": "Equity",
+            "Jahresgewinn oder Jahresverlust": {
+                "account_number": "9200"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Chart of accounts was missing for Switzerland. Here is the JSON file which has been created using official document link (https://www.kmu.admin.ch/dam/kmu/de/dokumente/savoir-pratique/Finances/240812%20Schulkontenrahmen%20VEB%20-%20DE.pdf.download.pdf/240812%20Schulkontenrahmen%20VEB%20-%20DE.pdf)

This is available in German with account numbers.